### PR TITLE
fix: align semconv schema URL with dependency version

### DIFF
--- a/src/SoapClientInstrumentation.php
+++ b/src/SoapClientInstrumentation.php
@@ -31,7 +31,7 @@ class SoapClientInstrumentation
         $instrumentation = new CachedInstrumentation(
             'io.opentelemetry.contrib.php.soap-client',
             InstalledVersions::getVersion('ycchuang99/opentelemetry-auto-soap-client'),
-            Version::VERSION_1_36_0->url(),
+            Version::VERSION_1_37_0->url(),
         );
 
         hook(


### PR DESCRIPTION
## Summary
- align the instrumentation schema URL with the declared `open-telemetry/sem-conv` dependency version
- update `SoapClientInstrumentation` from schema 1.36.0 to 1.37.0

## Test Plan
- composer validate --no-plugins
- vendor/bin/phpunit --testsuite unit --colors=never
- php -r "require 'vendor/autoload.php'; echo OpenTelemetry\\\\SemConv\\\\Version::VERSION_1_37_0->url(), PHP_EOL;"\n\nCloses #45